### PR TITLE
qa: Test all current available WooCommerce versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ before_install:
     phpunit/phpunit:$PHPUNIT_VERSION \
     wpackagist-plugin/woocommerce:$WOO_VERSION
   # Rerun install because downloading WordPress will overwrite plugins
-  - composer install
+  - composer install --ignore-platform-reqs
 
 install:
   - vendor/bin/wp --allow-root config create --force --dbuser=travis --dbpass="" --dbhost="127.0.0.1" --skip-check
@@ -81,6 +81,8 @@ script:
   - composer validate --strict --no-check-lock
   - vendor/bin/phpunit --coverage-clover coverage.xml
   - vendor/bin/phpstan analyse --no-progress lib/
+  # Check if platform requirements would be a problem for others
+  - composer install --no-dev
 
 after_script:
   # upload coverage.xml file to Coveralls to analyze it

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,8 @@ before_install:
     johnpbloch/wordpress:$WP_VERSION \
     phpunit/phpunit:$PHPUNIT_VERSION \
     wpackagist-plugin/woocommerce:$WOO_VERSION
+  # Rerun install because downloading WordPress will overwrite plugins
+  - composer install
 
 install:
   - vendor/bin/wp --allow-root config create --force --dbuser=travis --dbpass="" --dbhost="127.0.0.1" --skip-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,19 @@ env:
   global:
     - PHPUNIT_VERSION="~7|~8"
     - COMPOSER_CACHE_DIR=/home/travis/.composer
-    - WOO_VERSION="3.6.*"
+    - WOO_VERSION="3.7.*"
     - WP_VERSION="*"
   matrix:
     # see https://codex.wordpress.org/WordPress_Versions
     # see https://phpunit.de/supported-versions.html
-    - WP_VERSION=4.8.*
-    - WP_VERSION=4.8.* WOO_VERSION="3.4.*"
-    - WP_VERSION=4.8.* WOO_VERSION="3.2.*"
-    - WP_VERSION=4.8.* WOO_VERSION="3.0.*"
-    - WP_VERSION=4.8.* WOO_VERSION="3.0.*"
-    - WP_VERSION=5.0.*
     - WP_VERSION=5.2.*
+    - WP_VERSION=5.1.* WOO_VERSION="3.6.*"
+    - WP_VERSION=5.0.* WOO_VERSION="3.5.*"
+    - WP_VERSION=4.9.* WOO_VERSION="3.4.*"
+    - WP_VERSION=4.8.* WOO_VERSION="3.3.*"
+    - WP_VERSION=4.7.* WOO_VERSION="3.2.*"
+    - WP_VERSION=4.6.* WOO_VERSION="3.1.*"
+    - WP_VERSION=4.5.* WOO_VERSION="3.0.*"
     - WP_VERSION=dev-master
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ cache:
     - $HOME/.composer
 
 before_install:
+  - phpenv config-rm xdebug.ini
   - mysql -e 'CREATE DATABASE dev;'
   # Try supporting other versions
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ cache:
     - $HOME/.composer
 
 before_install:
-  - phpenv config-rm xdebug.ini
   - mysql -e 'CREATE DATABASE dev;'
   # Try supporting other versions
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ script:
 
 after_script:
   # upload coverage.xml file to Coveralls to analyze it
+  - composer require php-coveralls/php-coveralls # reinstall dev
   - vendor/bin/coveralls --verbose
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
     - COMPOSER_CACHE_DIR=/home/travis/.composer
     - WOO_VERSION="3.7.*"
     - WP_VERSION="*"
+    # All jobs shall share the composer cache
+    - CACHE_NAME=$TRAVIS_BRANCH
   matrix:
     # see https://codex.wordpress.org/WordPress_Versions
     # see https://phpunit.de/supported-versions.html
@@ -55,7 +57,7 @@ services:
 
 cache:
   directories:
-    - /home/travis/.composer
+    - $HOME/.composer
 
 before_install:
   - mysql -e 'CREATE DATABASE dev;'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ By now we bring helper for:
 * **WordPress** 4.5 - 5.2, e.g. posts, pages, user, options etc.
 * **WooCommerce** 3.0 - 3.7, e.g. orders, products etc.
 
-See below how a small Yaml-File can seed the database with tons of entries.
+See below how a small Yaml-File can seed the database with tons of entries
+or [read the documentation](https://github.com/rmp-up/wp-fixtures/releases)
+to find out more about entities and possibilities.
 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Overall the goal is **simplicity** and **no time wasting crap** (for me and you)
 which we achieve by using raw WordPress structures in the YAML instead of
 reinventing the wheel.
 
+By now we bring helper for:
+
+* **WordPress** 4.5 - 5.2, e.g. posts, pages, user, options etc.
+* **WooCommerce** 3.0 - 3.7, e.g. orders, products etc.
+
+See below how a small Yaml-File can seed the database with tons of entries.
+
+
 ## Install
 
 Download or just
@@ -29,8 +37,8 @@ Download or just
 We mostly require what Alice also needs
 ([see Packagist.org for more details](https://packagist.org/packages/rmp-up/wp-fixtures)):
 
-* PHP 7.1 - 7.3
-* WordPress 5.0
+* PHP
+* WordPress
 
 Optional:
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
   },
   "require-dev": {
     "johnpbloch/wordpress": "5.2.*",
-    "php-coveralls/php-coveralls": "1.1.*",
     "phpstan/phpstan": "0.11.*",
     "phpunit/phpunit": "7.5.*|8.2.*",
     "pretzlaw/phpunit-docgen": "2.1.*|3.0.*",


### PR DESCRIPTION
* Also store composer cache for all builds on a branch
* Install 2 times because WordPress overwrites plugins some times
  when it is fetched after the plugins (in srv/wp-content/plugins)
* Check if installation is possible for current PHP version
* Install coveralls on CI only and no longer on dev machines