### PR TITLE
fixtures: Allowed further classes (esp. WP_Object_Cache)

### DIFF
--- a/lib/Faker/BypassConstructorInstantiator.php
+++ b/lib/Faker/BypassConstructorInstantiator.php
@@ -76,8 +76,11 @@ class BypassConstructorInstantiator extends AbstractChainableInstantiator
     {
         $instance = (new ReflectionClass($fixture->getClassName()))->newInstanceWithoutConstructor();
 
-        if (is_callable($this->classNames[$fixture->getClassName()])) {
-            $this->classNames[$fixture->getClassName()]($instance);
+        $instanceCreator = (array) $this->classNames[$fixture->getClassName()];
+        foreach ($instanceCreator as $creator) {
+            if (is_callable($creator)) {
+                $creator($instance);
+            }
         }
 
         return $instance;

--- a/lib/Faker/Instantiator/AssertPropertiesAreAccessible.php
+++ b/lib/Faker/Instantiator/AssertPropertiesAreAccessible.php
@@ -1,0 +1,54 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * MakePropertiesWritable.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-fixtures
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WordPress\Fixtures\Faker\Instantiator;
+
+use ReflectionProperty;
+
+/**
+ * MakePropertiesWritable
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class AssertPropertiesAreAccessible
+{
+    /**
+     * @var array
+     */
+    private $properties;
+
+    public function __construct(array $properties)
+    {
+        $this->properties = $properties;
+    }
+
+    /**
+     * @param object $instance
+     */
+    public function __invoke($instance)
+    {
+        $class = get_class($instance);
+        foreach ($this->properties as $propertyName) {
+            (new ReflectionProperty($class, $propertyName))->setAccessible(true);
+        }
+    }
+}

--- a/lib/Faker/WordPressFixtureLoader.php
+++ b/lib/Faker/WordPressFixtureLoader.php
@@ -38,10 +38,12 @@ use RmpUp\WordPress\Fixtures\Faker\Generator\AutoFillIdIntoField;
 use RmpUp\WordPress\Fixtures\Faker\Generator\DateTimeFormat;
 use RmpUp\WordPress\Fixtures\Faker\Generator\ExpandPrefix;
 use RmpUp\WordPress\Fixtures\Faker\Generator\ReduceToReference;
+use RmpUp\WordPress\Fixtures\Faker\Instantiator\AssertPropertiesAreAccessible;
 use RmpUp\WordPress\Fixtures\Faker\WordPress\WpPostProvider;
 use RmpUp\WordPress\Fixtures\Faker\WordPress\WpUserProvider;
 use stdClass;
 use WP_Comment;
+use WP_Object_Cache;
 use WP_Post;
 use WP_Role;
 use WP_Site;
@@ -78,6 +80,13 @@ class WordPressFixtureLoader extends NativeLoader
         return new BypassConstructorInstantiator(
             [
                 WP_Comment::class,
+                WP_Object_Cache::class => [
+                    new AssertPropertiesAreAccessible([
+                        'blog_prefix',
+                        'global_groups',
+                        'multisite',
+                    ])
+                ],
                 WP_Post::class => static function ($instance) {
                     $instance->tax_input = [];
                 },

--- a/opt/doc/WordPress/Other/WpCommentQueryTest.php
+++ b/opt/doc/WordPress/Other/WpCommentQueryTest.php
@@ -1,0 +1,60 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * WpCommentQueryTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-fixtures
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WordPress\Fixtures\Test\WordPress\Other;
+
+use RmpUp\WordPress\Fixtures\Test\TestCase;
+use WP_Comment_Query;
+use WP_Date_Query;
+
+/**
+ * WP_Comment_Query
+ *
+ * The comment query finds and loads multiple comments from the database.
+ * If you develop a plugin to optimize or change such queries
+ * you surely want to have a big bunch of test scenarios like this:
+ *
+ * ```yaml
+ * WP_Comment_Query:
+ *   some_comment_query_{1..10}:
+ *     query_vars:
+ *       include_unapproved: 1
+ *       search: <word()>
+ *       date_query:
+ *         after: 4 weeks ago
+ * ```
+ *
+ * This will give you 10 comment queries searching for some random word
+ * in all unapproved comments.
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class WpCommentQueryTest extends TestCase
+{
+    public function testGetComments()
+    {
+        /** @var WP_Comment_Query $query */
+        $query = $this->fixtures['some_comment_query_1'];
+
+        self::assertInstanceOf(WP_Comment_Query::class, $query);
+    }
+}

--- a/opt/doc/WordPress/Other/WpObjectCacheTest.php
+++ b/opt/doc/WordPress/Other/WpObjectCacheTest.php
@@ -1,0 +1,76 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * WpObjectCacheTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-fixtures
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WordPress\Fixtures\Test\WordPress\Other;
+
+use RmpUp\WordPress\Fixtures\Test\TestCase;
+use WP_Object_Cache;
+use WP_Post;
+
+/**
+ * WP_Object_Cache
+ *
+ * To prepare/fill an object cache with some data (for testing purposes)
+ * you can create your own object-cache like this:
+ *
+ * ```yaml
+ * WP_Post:
+ *   test_1_post:
+ *     ID: 1337
+ *     title: <word()>
+ *
+ * WP_Object_Cache:
+ *   test_1_object_cache:
+ *     cache:
+ *       multisite: 0
+ *       posts:
+ *         1337: "@test_1_post"
+ * ```
+ *
+ * This way you just faked the post with the ID 1337
+ * so that `get_post(1337)` would return this post,
+ * if you use "test_1_object_cache" for the global `$wp_object_cache`.
+ *
+ * For a multisite this would
+ * Please note that "1:1337" is the key when you are running a multi-site.
+ * If you are dealing with a single-site installation then using
+ * "1337" as key would be enough.
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class WpObjectCacheTest extends TestCase
+{
+    public function testObjectCacheFakesPost()
+    {
+        /** @var WP_Object_Cache $cache */
+        $cache = $this->fixtures['test_1_object_cache'];
+
+        static::assertInstanceOf(WP_Object_Cache::class, $cache);
+        static::assertEquals(0, $cache->multisite);
+
+        /** @var WP_Post $post */
+        $post = $cache->get(1337, 'posts');
+
+        static::assertInstanceOf(WP_Post::class, $post);
+        self::assertEquals(1337, (int) $post->ID);
+    }
+}

--- a/opt/doc/WordPress/Other/WpTermQueryTest.php
+++ b/opt/doc/WordPress/Other/WpTermQueryTest.php
@@ -1,0 +1,58 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * WpTermQueryTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-fixtures
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WordPress\Fixtures\Test\WordPress\Other;
+
+use RmpUp\WordPress\Fixtures\Test\TestCase;
+use WP_Term_Query;
+
+/**
+ * WP_Term_Query
+ *
+ * The term query finds and loads multiple terms from the database.
+ * If you develop a plugin to optimize or change such queries
+ * you surely want to have a big bunch of test scenarios like this:
+ *
+ * ```yaml
+ * WP_Term_Query:
+ *   some_term_query_{1..10}:
+ *     query_vars:
+ *       taxonomy: category
+ *       name: <word()>
+ *       hide_empty: 0
+ * ```
+ *
+ * This will give you 10 queries searching for some random term
+ * within the category taxonomy.
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class WpTermQueryTest extends TestCase
+{
+    public function testGetTermQueries()
+    {
+        /** @var WP_Term_Query $query */
+        $query = $this->fixtures['some_term_query_1'];
+
+        self::assertInstanceOf(WP_Term_Query::class, $query);
+    }
+}

--- a/opt/doc/WordPress/Other/WpUserQueryTest.php
+++ b/opt/doc/WordPress/Other/WpUserQueryTest.php
@@ -1,0 +1,57 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * WpUserQueryTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-fixtures
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WordPress\Fixtures\Test\WordPress\Other;
+
+use RmpUp\WordPress\Fixtures\Test\TestCase;
+use WP_User_Query;
+
+/**
+ * WP_User_Query
+ *
+ * The user query finds and loads multiple users from the database.
+ * If you develop a plugin to optimize or change such queries
+ * you surely want to have a big bunch of test scenarios like this:
+ *
+ * ```yaml
+ * WP_User_Query:
+ *   some_user_query_{1..10}:
+ *     query_vars:
+ *       has_published_posts: 0
+ *       search: <word()>
+ * ```
+ *
+ * This will give you 10 queries searching for some random word
+ * among all user without a published post.
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class WpUserQueryTest extends TestCase
+{
+    public function testGetUserQueries()
+    {
+        /** @var WP_User_Query $query */
+        $query = $this->fixtures['some_user_query_1'];
+
+        self::assertInstanceOf(WP_User_Query::class, $query);
+    }
+}

--- a/opt/doc/WordPress/OtherTest.php
+++ b/opt/doc/WordPress/OtherTest.php
@@ -1,0 +1,43 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * OtherTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-fixtures
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace RmpUp\WordPress\Fixtures\Test\WordPress;
+
+use RmpUp\WordPress\Fixtures\Test\TestCase;
+
+/**
+ * Other
+ *
+ * There are more entities that can be created
+ * but not persisted so far.
+ * Either because it is not yet implemented
+ * or because WordPress just uses these classes internally.
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class OtherTest extends TestCase
+{
+    public function testOther()
+    {
+        static::assertTrue(true);
+    }
+}

--- a/opt/doc/WordPressTest.php
+++ b/opt/doc/WordPressTest.php
@@ -35,7 +35,7 @@ use Symfony\Component\Finder\Finder;
  * for testing purposes
  * or to show your customer different examples how a website could look like.
  *
- * In terms of WordPress you can fill the following types/things with data:
+ * In terms of WordPress you can fill the following entities with data:
  *
  * * Options
  * * WP_Comment
@@ -44,6 +44,14 @@ use Symfony\Component\Finder\Finder;
  * * WP_Site
  * * WP_Term
  * * WP_User
+ *
+ * And they can also be persisted to the database.
+ *
+ * Furthermore the following data-objects can be filled with life:
+ *
+ * * WP_Comment_Query
+ * * WP_Term_Query
+ * * WP_User_Query
  *
  * @copyright 2020 Pretzlaw (https://rmp-up.de)
  */
@@ -157,7 +165,6 @@ class WordPressTest extends TestCase
      * * WP_Admin_Bar
      * * WP_Ajax_Response
      * * WP_Block_*
-     * * WP_Comment_Query
      * * WP_Customize_*
      * * WP_Date_Query
      * * WP_Embed
@@ -189,12 +196,10 @@ class WordPressTest extends TestCase
      * * WP_Site_Query
      * * WP_Tax_Query
      * * WP_Taxonomy
-     * * WP_Term_Query
      * * WP_Text_Diff_Renderer_Table
      * * WP_Text_Diff_Renderer_inline
      * * WP_Theme
      * * WP_User_Meta_Session_Tokens
-     * * WP_User_Query
      * * WP_User_Request
      * * WP_Widget
      * * WP_Widget_*
@@ -202,12 +207,7 @@ class WordPressTest extends TestCase
      * * WP_oEmbed_Controller
      * * WP_Object_Cache
      * * Walker
-     * * Walker_Category
-     * * Walker_CategoryDropdown
-     * * Walker_Comment
-     * * Walker_Nav_Menu
-     * * Walker_Page
-     * * Walker_PageDropdown
+     * * Walker_*
      * * _WP_Dependency
      * * _WP_Editors
      * * wp_xmlrpc_server
@@ -217,7 +217,10 @@ class WordPressTest extends TestCase
     public function testScope()
     {
         $coveredClasses = array_flip(
-            $this->classComment()->ul(0)->li()->all()->map('strval')->getArrayCopy()
+            array_merge(
+                $this->classComment()->ul(0)->li()->all()->map('strval')->getArrayCopy(),
+                $this->classComment()->ul(1)->li()->all()->map('strval')->getArrayCopy()
+            )
         );
 
         $ignoredClasses = array_flip(


### PR DESCRIPTION
* AssertPropertiesAreAccessible can give access
  to private or protected fields

see #14 